### PR TITLE
feat: Enhance ArangoDB insert_many method with batching and sanitization options

### DIFF
--- a/app/odk/services/data_download.py
+++ b/app/odk/services/data_download.py
@@ -321,7 +321,8 @@ async def insert_many_data_to_arangodb(data: List[dict], overwrite_mode: str = '
 
 
         db:ArangoDBClient = await get_arangodb_client()
-        await db.insert_many(collection_name=db_collections.VA_TABLE, documents=data,overwrite_mode = overwrite_mode)
+        # Pass sanitize=False since we already sanitized above to avoid double processing
+        return await db.insert_many(collection_name=db_collections.VA_TABLE, documents=data, overwrite_mode=overwrite_mode, sanitize=False)
 
     except Exception as e:
         print(e)


### PR DESCRIPTION
- Updated the insert_many method in ArangoDBClient to support batch processing for improved performance with large datasets.
- Added a sanitize parameter to control document sanitization, allowing for upstream sanitization to be skipped.
- Improved the _insert_many_sync method to handle both small and large document sets efficiently, with detailed comments for clarity.